### PR TITLE
Add google-cloud-bigquery-storage package for faster BigQuery reads

### DIFF
--- a/t4d-superset-base-image/Dockerfile.t4d.template
+++ b/t4d-superset-base-image/Dockerfile.t4d.template
@@ -28,7 +28,7 @@ RUN pip install --upgrade pip
 RUN . /app/.venv/bin/activate && \
     uv pip install \
     # install psycopg2 for using PostgreSQL metadata store - could be a MySQL package if using that backend:
-    psycopg2-binary pymssql sqlalchemy-bigquery pandas-gbq flask_cors Flask-Mail asyncpg \
+    psycopg2-binary pymssql sqlalchemy-bigquery pandas-gbq google-cloud-bigquery-storage flask_cors Flask-Mail asyncpg \
       # packages needed for various Superset features:  
     google-auth python-dotenv urllib3 requests botocore python-dotenv redis celery flower pytz\
 


### PR DESCRIPTION
## Summary
- Added `google-cloud-bigquery-storage` package to `Dockerfile.t4d.template` for faster BigQuery reads from clients using BigQuery as their data warehouse
- This is part of the Superset 5.0.0 → 6.0.0 upgrade

## Related ticket
DALGO-1269
